### PR TITLE
タイムゾーンとローケルの設定及び、一部gemfile追加

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -25,6 +25,9 @@ gem 'jbuilder', '~> 2.7'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
+gem 'rails-i18n'
+gem 'kaminari'
+gem 'devise'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -29,7 +29,10 @@ module App
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "tokyo"
+    config.i18n.load_path = +=
+    Dir[Rails.root.join("config", "locales", "**", "*.{rb.yml}").to_s]
+    config.i18n.default_locale = :ja
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.


### PR DESCRIPTION
 - タイムゾーンを日本時間に変更
 - ローケルファイルのロードパスの設定
 - config/localesディレクトリ以下を再帰的に読み込む設定にしています
 - デフォルトロケールを「日本語（ja）」に設定

